### PR TITLE
Fix spelling of Ubuntu in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Below is a table that provides examples for the nomenclature:
 
 | image name | OS ver | ffmpeg ver | variant | description
 | --- | --- | --- | --- | --- |
-| ffmpeg-7.1-ubuntu2404 | 24.04 | 6.x - 7.x | [ubuntu](https://releases.ubuntu.com/) | external libraries are installed from os packages, and ffmpeg is built from source. See [Ubunu Compilation Guide](https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu) for details on this. |
-| ffmpeg-7.1-ubuntu2404-edge | 24.04 | 6.x - 7.x | [ubuntu](https://releases.ubuntu.com/) | libs and ffmpeg are built from source. See [Ubunu Compilation Guide](https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu) for details on this. |
+| ffmpeg-7.1-ubuntu2404 | 24.04 | 6.x - 7.x | [ubuntu](https://releases.ubuntu.com/) | external libraries are installed from os packages, and ffmpeg is built from source. See [Ubuntu Compilation Guide](https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu) for details on this. |
+| ffmpeg-7.1-ubuntu2404-edge | 24.04 | 6.x - 7.x | [ubuntu](https://releases.ubuntu.com/) | libs and ffmpeg are built from source. See [Ubuntu Compilation Guide](https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu) for details on this. |
 | ffmpeg-7.1-vaapi2404 | 24.04 | 6.x - 7.x | [ubuntu](https://releases.ubuntu.com/) | like: `ubuntu2404` but enables: [Video Acceleration API (VAAPI)](https://trac.ffmpeg.org/wiki/HWAccelIntro#VAAPI) in ffmpeg |
 | ffmpeg-7.1-nvidia2204-edge | 22.04 | 6.x - 7.x | [ubuntu](https://releases.ubuntu.com/) | Built w/ [NVIDIA's hardware-accelerated encoding and decoding APIs](https://trac.ffmpeg.org/wiki/HWAccelIntro#CUDANVENCNVDEC) enabled |
 | ffmpeg-7.1-alpine320 | 3.20 | 6.x - 7.x | [alpine](https://alpinelinux.org/releases/) | vendor libs, but ffmpeg is built from source |


### PR DESCRIPTION
I was reading the readme and found two instances of "Ubunu" so I changed them to be "Ubuntu"